### PR TITLE
I modified regex for matching with filename having extensions in series.

### DIFF
--- a/gridfsfusepy.py
+++ b/gridfsfusepy.py
@@ -100,7 +100,7 @@ class FuseGridFS(LoggingMixIn, Operations):
         path = self.fix_path(path)
         map_function = Code('''
         function () {
-            var re = /^%s([\w ]+(?:\.[\w ]+)?)$/;
+            var re = /^%s([\w ]+(?:\.[\w ]+)*)$/;
             emit(re(this.filename)[1], 1);
         }
         ''' % path)
@@ -110,7 +110,7 @@ class FuseGridFS(LoggingMixIn, Operations):
             return 1;
         }
         ''')
-        res = self.collection.files.map_reduce(map_function, reduce_function, out='dirs', query={'filename' : { '$regex' : '^{0}([\w ]+(?:\.[\w ]+)?)$'.format(path) }})
+        res = self.collection.files.map_reduce(map_function, reduce_function, out='dirs', query={'filename' : { '$regex' : '^{0}([\w ]+(?:\.[\w ]+)*)$'.format(path) }})
         if res.count() > 0:
             return [a['_id'] for a in res.find()]
         return []


### PR DESCRIPTION
For example, the regex match only with "foo.tar" but not with "foo.tar.gz".
So optional extention expressed in '?' at the end of original replaced by '*',
which means extension can be repeated zero or more times.
